### PR TITLE
Parse ERB when loading data from YAML files

### DIFF
--- a/lib/reader/symbolmatrix.rb
+++ b/lib/reader/symbolmatrix.rb
@@ -7,11 +7,11 @@ module Reader
     end
 
     def file path
-      @source.merge! YAML.load_file path
+      yaml(File.read(path))
     end
 
     def yaml data
-      @source.merge! YAML.load data
+      @source.merge! YAML.load(ERB.new(data).result)
     end
 
     def serialization data

--- a/lib/symbolmatrix.rb
+++ b/lib/symbolmatrix.rb
@@ -1,5 +1,6 @@
 require 'yaml'
 require 'json'
+require 'erb'
 require 'discoverer'
 
 require 'symbolmatrix/symbolmatrix'

--- a/spec/reader/symbolmatrix_spec.rb
+++ b/spec/reader/symbolmatrix_spec.rb
@@ -1,78 +1,78 @@
 require 'complete_features_helper'
 
-describe Reader::SymbolMatrix do 
-  describe '#initialize' do 
-    it 'should receive a source and add it as source' do 
-      source = stub 'source'
+describe Reader::SymbolMatrix do
+  describe '#initialize' do
+    it 'receives a source and add it as source' do
+      source = double 'source'
       reader = Reader::SymbolMatrix.new source
-      reader.source.should == source
+      expect(reader.source).to eq source
     end
   end
 
   describe "#yaml" do
-    it "should call #merge! the source using the parsed YAML data as argument" do
+    it "calls #merge! the source using the parsed YAML data as argument" do
       sample_yaml = "a: { nested: { data: with, very: much }, content: to find }"
-      the_stub = stub "a theoretical SymbolMatrix"
+      the_stub = double "a theoretical SymbolMatrix"
       reader = Reader::SymbolMatrix.new the_stub
-      the_stub.should_receive(:merge!).with "a" => { "nested" => { "data" => "with", "very" => "much" }, "content" => "to find" }
+      expect(the_stub).to receive(:merge!).with "a" => { "nested" => { "data" => "with", "very" => "much" }, "content" => "to find" }
       reader.yaml sample_yaml
     end
   end
-  
+
   describe "#file" do
     context "there is a YAML file in the given path" do
       before do
         Fast.file.write "temp/data.yaml", "a: { nested: { data: with, very: much }, content: to find }"
       end
-      
-      it "should call #merge! on the source using the parsed YAML data found in the file" do
-        the_stub = stub "a theoretical SymbolMatrix"
+
+      it "calls #merge! on the source using the parsed YAML data found in the file" do
+        the_stub = double "a theoretical SymbolMatrix"
         reader = Reader::SymbolMatrix.new the_stub
-        the_stub.should_receive(:merge!).with "a" => { "nested" => { "data" => "with", "very" => "much" }, "content" => "to find" }
+        expect(the_stub).to receive(:merge!).with "a" => { "nested" => { "data" => "with", "very" => "much" }, "content" => "to find" }
         reader.file "temp/data.yaml"
       end
-      
+
       after do
         Fast.dir.remove! :temp
       end
     end
   end
 
-  shared_examples_for "any reader serialization" do 
-    it 'should call merge! to source with the parsed data' do 
-      the_sm = stub 'sm'
-      data_stub = stub 'data'
-      ready_to_merge = stub 'ready to merge'
+  shared_examples_for "any reader serialization" do
+    it 'calls merge! to source with the parsed data' do
+      the_sm = double 'sm'
+      data_stub = double 'data'
+      ready_to_merge = double 'ready to merge'
       reader = Reader::SymbolMatrix.new the_sm
-      SymbolMatrix::Serialization.should_receive(:parse).with(data_stub).and_return ready_to_merge
-      the_sm.should_receive(:merge!).with ready_to_merge
+      expect(SymbolMatrix::Serialization).to receive(:parse).with(data_stub).and_return ready_to_merge
+      expect(the_sm).to receive(:merge!).with ready_to_merge
       reader.send @method, data_stub
     end
   end
 
-  describe "#serialization" do 
+  describe "#serialization" do
     before { @method = :serialization }
     it_behaves_like 'any reader serialization'
   end
 
-  describe '#smas' do 
+  describe '#smas' do
     before { @method = :smas }
     it_behaves_like 'any reader serialization'
   end
 end
 
 describe SymbolMatrix do
-  it 'should include the Discoverer for Reader' do 
-    SymbolMatrix.ancestors.should include Discoverer::Reader
+  it 'includes the Discoverer for Reader' do
+    expect(SymbolMatrix.ancestors).to include Discoverer::Reader
   end
 
-  it 'should feature a deprecation notice in #from_yaml' do
-    Kernel.should_receive(:warn).with "[DEPRECATION]: #from_yaml is deprecated, please use #from.yaml instead" 
-    SymbolMatrix.new.from_yaml stub 'argument'
+  it 'features a deprecation notice in #from_yaml' do
+    expect(Kernel).to receive(:warn).with "[DEPRECATION]: #from_yaml is deprecated, please use #from.yaml instead"
+    SymbolMatrix.new.from_yaml double 'argument'
   end
 
-  it 'should feature a deprecation notice in #from_file' do 
-    Kernel.should_receive(:warn).with "[DEPRECATION]: #from_file is deprecated, please use #from.file instead" 
-    SymbolMatrix.new.from_file stub 'argument'
+  it 'features a deprecation notice in #from_file' do
+    expect(Kernel).to receive(:warn).with "[DEPRECATION]: #from_file is deprecated, please use #from.file instead"
+    SymbolMatrix.new.from_file double 'argument'
   end
 end

--- a/spec/symbolmatrix/serialization_spec.rb
+++ b/spec/symbolmatrix/serialization_spec.rb
@@ -1,80 +1,92 @@
 require 'complete_features_helper'
 
 describe SymbolMatrix::Serialization do
-  describe '.parse' do 
-    it 'should parse an empty string' do 
+  describe '.parse' do
+    it 'parses an empty string' do
       sm = SymbolMatrix::Serialization.parse ""
-      sm.keys.should be_empty
+      expect(sm.keys).to be_empty
     end
 
-    it 'should parse a simple string aja:hola' do
+    it 'parses a simple string aja:hola' do
       sm = SymbolMatrix::Serialization.parse 'aja:hola'
-      sm.aja.should == 'hola'
+      expect(sm.aja).to eq 'hola'
     end
 
-    it 'should parse another simple string esto:distinto' do 
-      SymbolMatrix::Serialization
-        .parse('esto:distinto')
-        .esto.should == "distinto"
+    it 'parses another simple string esto:distinto' do
+      expect(
+        SymbolMatrix::Serialization
+          .parse('esto:distinto')
+          .esto
+      ).to eq "distinto"
     end
 
-    it 'should parse to a number when is a number' do
-      SymbolMatrix::Serialization
-        .parse("esto:3442")
-        .esto.should == 3442
+    it 'parses to a number when is a number' do
+      expect(
+        SymbolMatrix::Serialization
+          .parse("esto:3442")
+          .esto
+      ).to eq 3442
     end
 
-    it 'should parse a more complex string' do 
+    it 'parses a more complex string' do
       sm = SymbolMatrix::Serialization.parse 'hola:eso que:pensas'
-      sm.hola.should == 'eso'
-      sm.que.should == 'pensas'
+      expect(sm.hola).to eq 'eso'
+      expect(sm.que).to eq 'pensas'
     end
 
-    it 'should parse another complex string' do 
+    it 'parses another complex string' do
       sm = SymbolMatrix::Serialization
         .parse("esto:es bastante:original gracias:bdd")
-      sm.esto.should == "es"
-      sm.bastante.should == "original"
-      sm.gracias.should == "bdd"
+      expect(sm.esto).to eq "es"
+      expect(sm.bastante).to eq "original"
+      expect(sm.gracias).to eq "bdd"
     end
 
-    it 'should parse a string with a single dot' do 
-      SymbolMatrix::Serialization
-        .parse("just.one:dot")
-        .just.one.should == "dot"
+    it 'parses a string with a single dot' do
+      expect(
+        SymbolMatrix::Serialization
+          .parse("just.one:dot")
+          .just.one
+      ).to eq "dot"
     end
 
-    it 'should parse another string with single dot' do 
-      SymbolMatrix::Serialization
-        .parse("just.one:point")
-        .just.one.should == "point"
+    it 'parses another string with single dot' do
+      expect(
+        SymbolMatrix::Serialization
+          .parse("just.one:point")
+          .just.one
+      ).to eq "point"
     end
 
-    it 'should parse another one, other var name' do 
-      SymbolMatrix::Serialization
-        .parse("just.another:data")
-        .just.another.should == "data"
+    it 'parses another one, other var name' do
+      expect(
+        SymbolMatrix::Serialization
+          .parse("just.another:data")
+          .just.another
+      ).to eq "data"
     end
 
-    it 'should parse a string with dots' do
-      SymbolMatrix::Serialization
-        .parse("the.one.with:dots")
-        .the.one.with.should == "dots"
+    it 'parses a string with dots' do
+      expect(
+        SymbolMatrix::Serialization
+          .parse("the.one.with:dots")
+          .the.one.with
+      ).to eq "dots"
     end
 
-    it 'should parse a string with dots and spaces' do
+    it 'parses a string with dots and spaces' do
       sm = SymbolMatrix::Serialization
         .parse("in.one.with:dots the.other.with:dots")
-      sm.the.other.with.should == "dots"
-      sm.in.one.with.should == "dots"
-    end    
+      expect(sm.the.other.with).to eq "dots"
+      expect(sm.in.one.with).to eq "dots"
+    end
 
-    it 'should merge recursively when needed' do 
+    it 'merges recursively when needed' do
       sm = SymbolMatrix::Serialization
         .parse("client.host:localhost client.path:hola")
 
-      sm.client.host.should == "localhost"
-      sm.client.path.should == "hola"
+      expect(sm.client.host).to eq "localhost"
+      expect(sm.client.path).to eq "hola"
     end
   end
 end
@@ -82,39 +94,39 @@ end
 describe SymbolMatrix do
   describe "#initialize" do
     context "a valid path to a file is provided" do
-      before do 
+      before do
         Fast.file.write "temp/data.yaml", "a: { nested: { data: with, very: much }, content: to find }"
       end
-      
-      it "should load the data into self" do
+
+      it "loads the data into self" do
         f = SymbolMatrix.new "temp/data.yaml"
-        f.a.nested.data.should == "with"
+        expect(f.a.nested.data).to eq "with"
       end
 
       after do
         Fast.dir.remove! :temp
       end
     end
-    
+
     context "a YAML string is provided" do
-      it "should load the data into self" do
+      it "loads the data into self" do
         e = SymbolMatrix.new "beta: { nano: { data: with, very: much }, content: to find }"
-        e.beta.nano[:very].should == "much"
+        expect(e.beta.nano[:very]).to eq "much"
       end
     end
 
-    context "a SymbolMatrix serialization is provided" do 
-      it 'should load the data into self' do 
+    context "a SymbolMatrix serialization is provided" do
+      it 'loads the data into self' do
         a = SymbolMatrix.new "those.pesky:attempts of.making.it:work"
-        a.those.pesky.should == "attempts"
-        a.of.making.it.should == "work"
+        expect(a.those.pesky).to eq "attempts"
+        expect(a.of.making.it).to eq "work"
       end
     end
 
     context "an empty string is provided" do
-      it 'should load nothing into the SymbolMatrix' do 
+      it 'loads nothing into the SymbolMatrix' do
         a = SymbolMatrix ""
-        a.keys.should be_empty
+        expect(a.keys).to be_empty
       end
     end
   end

--- a/spec/symbolmatrix/symbolmatrix_spec.rb
+++ b/spec/symbolmatrix/symbolmatrix_spec.rb
@@ -3,7 +3,7 @@ require "plain_symbolmatrix_helper"
 describe SymbolMatrix do
   describe "#validate_key" do
     context "an not convertible to Symbol key is passed" do
-      it "should raise a SymbolMatrix::InvalidKeyException" do
+      it "raises a SymbolMatrix::InvalidKeyException" do
         m = SymbolMatrix.new
         o = Object.new
         expect { m.validate_key o
@@ -11,29 +11,29 @@ describe SymbolMatrix do
       end
     end
   end
-  
+
   describe "#store" do
     context "a key is stored using a symbol" do
-      it "should be foundable with #[<symbol]" do
+      it "is foundable with #[<symbol]" do
         a = SymbolMatrix.new
         a.store :a, 2
-        a[:a].should == 2
+        expect(a[:a]).to eq 2
       end
     end
-    
+
     context "the passed value is a Hash" do
-      it "should be converted into a SymbolTable" do
+      it "is converted into a SymbolTable" do
         a = SymbolMatrix.new
         a.store :b, { :c => 3 }
-        a[:b].should be_a SymbolMatrix
+        expect(a[:b]).to be_a SymbolMatrix
       end
     end
   end
-  
+
   shared_examples_for "any merging operation" do
-    it "should call :store for every item in the passed Hash" do
+    it "calls :store for every item in the passed Hash" do
       m = SymbolMatrix.new
-      m.should_receive(:store).exactly(3).times
+      expect(m).to receive(:store).exactly(3).times
       m.send @method, { :a => 1, :b => 3, :c => 4 }
     end
   end
@@ -41,234 +41,235 @@ describe SymbolMatrix do
   describe "#merge!" do
     before { @method = :merge! }
     it_behaves_like "any merging operation"
-  end  
-  
+  end
+
   describe "#update" do
     before { @method = :update }
     it_behaves_like "any merging operation"
   end
 
   describe "#merge" do
-    it "should call #validate_key for each passed item" do
+    it "calls #validate_key for each passed item" do
       m = SymbolMatrix.new
-      m.should_receive(:validate_key).exactly(3).times.and_return(true)
+      expect(m).to receive(:validate_key).exactly(3).times.and_return(true)
       m.merge :a => 2, :b => 3, :c => 4
     end
   end
 
   describe "#[]" do
     context "the matrix is empty" do
-      it "should raise a SymbolMatrix::KeyNotDefinedException" do
+      it "raises a SymbolMatrix::KeyNotDefinedException" do
         m = SymbolMatrix.new
         expect { m['t']
         }.to raise_error SymbolMatrix::KeyNotDefinedException, "The key :t is not defined"
       end
     end
-    
+
     context "the matrix has a key defined using a symbol" do
-      it "should return the same value when called with a string" do
+      it "returns the same value when called with a string" do
         m = SymbolMatrix.new
         m[:s] = 3
-        m["s"].should == 3
+        expect(m["s"]).to eq 3
       end
     end
   end
 
   describe "#to_hash" do
-    it "should show a deprecation notice" do
-      Kernel.should_receive(:warn).with "[DEPRECATION]: #to_hash is deprecated, please use #to.hash instead" 
+    it "shows a deprecation notice" do
+      expect(Kernel).to receive(:warn).with "[DEPRECATION]: #to_hash is deprecated, please use #to.hash instead"
       SymbolMatrix.new.to_hash
     end
   end
 
   describe ".new" do
     context "a Hash is passed as argument" do
-      it "should accept it" do
+      it "accepts it" do
         m = SymbolMatrix.new :a => 1
-        m["a"].should == 1
-        m[:a].should == 1
+        expect(m["a"]).to eq 1
+        expect(m[:a]).to eq 1
       end
     end
-  end    
+  end
 
   describe "method_missing" do
-    it "should store in a key named after the method without the '=' sign" do
+    it "stores in a key named after the method without the '=' sign" do
       m = SymbolMatrix.new
       m.a = 4
-      m[:a].should == 4
-    end
-    
-    it "should return the same as the symbol representation of the method" do
-      m = SymbolMatrix.new
-      m.a = 3
-      m[:a].should == 3
-      m["a"].should == 3
-      m.a.should == 3
+      expect(m[:a]).to eq 4
     end
 
-    it "should preserve the class of the argument" do
+    it "returns the same as the symbol representation of the method" do
+      m = SymbolMatrix.new
+      m.a = 3
+      expect(m[:a]).to eq 3
+      expect(m["a"]).to eq 3
+      expect(m.a).to eq 3
+    end
+
+    it "preserves the class of the argument" do
       class A < SymbolMatrix; end
       class B < SymbolMatrix; end
-      
+
       a = A.new
       b = B.new
 
       a.a = b
 
-      a.a.should be_instance_of B
+      expect(a.a).to be_instance_of B
     end
   end
 
-  describe "#recursive_merge" do 
-    it 'should raise a relevant error when the two matrices collide' do 
+  describe "#recursive_merge" do
+    it 'raises a relevant error when the two matrices collide' do
       sm = SymbolMatrix a: "hola"
       expect { sm.recursive_merge SymbolMatrix a: "hey"
       }.to raise_error SymbolMatrix::MergeError,
         "The value of the :a key is already defined. Run recursive merge with flag true if you want it to override"
     end
 
-    it 'should override on collide if the override flag is on' do 
+    it 'overrides on collide if the override flag is on' do
       sm = SymbolMatrix a: "hola"
       result = sm.recursive_merge SymbolMatrix(a: "hey"), true
-      result.a.should == "hey"
+      expect(result.a).to eq "hey"
     end
 
-    it 'should send the override directive into the recursion' do 
+    it 'sends the override directive into the recursion' do
       sm = SymbolMatrix a: { b: "hola" }
       result = sm.recursive_merge SymbolMatrix( a: { b: "hey" } ), true
-      result.a.b.should == "hey"
+      expect(result.a.b).to eq "hey"
     end
 
-    it 'should merge two symbolmatrices' do 
+    it 'merges two symbolmatrices' do
       sm = SymbolMatrix.new a: "hola"
       result = sm.recursive_merge SymbolMatrix.new b: "chau"
-      result.a.should == "hola"
-      result.b.should == "chau"
+      expect(result.a).to eq "hola"
+      expect(result.b).to eq "chau"
     end
 
-    it 'should merge two symbolmatrices (new values)' do 
+    it 'merges two symbolmatrices (new values)' do
       sm = SymbolMatrix.new a: "hey"
       result = sm.recursive_merge SymbolMatrix.new b: "bye"
-      result.a.should == "hey"
-      result.b.should == "bye"
+      expect(result.a).to eq "hey"
+      expect(result.b).to eq "bye"
     end
 
-    it 'should merge two symbolmatrices (new keys)' do 
+    it 'merges two symbolmatrices (new keys)' do
       sm = SymbolMatrix.new y: "allo"
       result = sm.recursive_merge SymbolMatrix.new z: "ciao"
-      result.y.should == "allo"
-      result.z.should == "ciao"
+      expect(result.y).to eq "allo"
+      expect(result.z).to eq "ciao"
     end
 
-    it 'should recursively merge this with that (simple)' do 
+    it 'recursively merges this with that (simple)' do
       sm = SymbolMatrix.new another: { b: "aa" }
       result = sm.recursive_merge SymbolMatrix.new another: { c: "ee" }
-      result.another.b.should == "aa"
-      result.another.c.should == "ee"
+      expect(result.another.b).to eq "aa"
+      expect(result.another.c).to eq "ee"
     end
 
-    it 'should recursively merge this with that (simple)' do 
+    it 'recursively merges this with that (simple)' do
       sm = SymbolMatrix.new distinct: { b: "rr" }
       result = sm.recursive_merge SymbolMatrix.new distinct: { c: "gg" }
-      result.distinct.b.should == "rr"
-      result.distinct.c.should == "gg"
+      expect(result.distinct.b).to eq "rr"
+      expect(result.distinct.c).to eq "gg"
     end
 
-    it 'should recursively merge this with that v2 (simple)' do
+    it 'recursively merges this with that v2 (simple)' do
       sm = SymbolMatrix.new a: { z: "ee" }
       result = sm.recursive_merge SymbolMatrix.new a: { g: "oo" }
-      result.a.z.should == "ee"
-      result.a.g.should == "oo"
+      expect(result.a.z).to eq "ee"
+      expect(result.a.g).to eq "oo"
     end
 
-    it 'should recursively merge this with the argument hash' do 
+    it 'recursively merges this with the argument hash' do
       sm = SymbolMatrix.new a: { b: { c: "hola" } }
       result = sm.recursive_merge a: { b: { d: "aaa" } }
-      result.a.b.c.should == "hola"
-      result.a.b.d.should == "aaa"
+      expect(result.a.b.c).to eq "hola"
+      expect(result.a.b.d).to eq "aaa"
     end
   end
 
-  describe '#recursive_merge!' do 
-    it 'should raise a relevant error when the two matrices collide' do 
+  describe '#recursive_merge!' do
+    it 'raises a relevant error when the two matrices collide' do
       sm = SymbolMatrix a: "hola"
       expect { sm.recursive_merge! SymbolMatrix a: "hey"
       }.to raise_error SymbolMatrix::MergeError,
         "The value of the :a key is already defined. Run recursive merge with flag true if you want it to override"
     end
 
-    it 'should override on collide if the override flag is on' do 
+    it 'overrides on collide if the override flag is on' do
       sm = SymbolMatrix a: "hola"
       sm.recursive_merge! SymbolMatrix(a: "hey"), true
-      sm.a.should == "hey"
+      expect(sm.a).to eq "hey"
     end
 
-    it 'should send the override directive into the recursion' do 
+    it 'sends the override directive into the recursion' do
       sm = SymbolMatrix a: { b: "hola" }
       sm.recursive_merge! SymbolMatrix( a: { b: "hey" } ), true
-      sm.a.b.should == "hey"
+      expect(sm.a.b).to eq "hey"
     end
 
-    it 'should merge a symbolmatrix into this' do 
+    it 'merges a symbolmatrix into this' do
       sm = SymbolMatrix.new a: "hola"
       sm.recursive_merge! SymbolMatrix.new b: "chau"
-      sm.a.should == "hola"
-      sm.b.should == "chau"
+      expect(sm.a).to eq "hola"
+      expect(sm.b).to eq "chau"
     end
 
-    it 'should merge two symbolmatrices (new values)' do 
+    it 'merges two symbolmatrices (new values)' do
       sm = SymbolMatrix.new a: "hey"
       sm.recursive_merge! SymbolMatrix.new b: "bye"
-      sm.a.should == "hey"
-      sm.b.should == "bye"
+      expect(sm.a).to eq "hey"
+      expect(sm.b).to eq "bye"
     end
 
-    it 'should merge two symbolmatrices (new keys)' do 
+    it 'merges two symbolmatrices (new keys)' do
       sm = SymbolMatrix.new y: "allo"
       sm.recursive_merge! SymbolMatrix.new z: "ciao"
-      sm.y.should == "allo"
-      sm.z.should == "ciao"
+      expect(sm.y).to eq "allo"
+      expect(sm.z).to eq "ciao"
     end
 
-    it 'should recursively merge this with that (simple)' do 
+    it 'recursively merges this with that (simple)' do
       sm = SymbolMatrix.new another: { b: "aa" }
       sm.recursive_merge! SymbolMatrix.new another: { c: "ee" }
-      sm.another.b.should == "aa"
-      sm.another.c.should == "ee"
+      expect(sm.another.b).to eq "aa"
+      expect(sm.another.c).to eq "ee"
     end
 
-    it 'should recursively merge this with that (simple)' do 
+    it 'recursively merges this with that (simple)' do
       sm = SymbolMatrix.new distinct: { b: "rr" }
       sm.recursive_merge! SymbolMatrix.new distinct: { c: "gg" }
-      sm.distinct.b.should == "rr"
-      sm.distinct.c.should == "gg"
+      expect(sm.distinct.b).to eq "rr"
+      expect(sm.distinct.c).to eq "gg"
     end
 
-    it 'should recursively merge this with that v2 (simple)' do
+    it 'recursively merges this with that v2 (simple)' do
       sm = SymbolMatrix.new a: { z: "ee" }
       sm.recursive_merge! SymbolMatrix.new a: { g: "oo" }
-      sm.a.z.should == "ee"
-      sm.a.g.should == "oo"
+      expect(sm.a.z).to eq "ee"
+      expect(sm.a.g).to eq "oo"
     end
 
-    it 'should recursively merge this with the argument hash' do 
+    it 'recursively merges this with the argument hash' do
       sm = SymbolMatrix.new a: { b: { c: "hola" } }
       sm.recursive_merge! a: { b: { d: "aaa" } }
-      sm.a.b.c.should == "hola"
-      sm.a.b.d.should == "aaa"
+      expect(sm.a.b.c).to eq "hola"
+      expect(sm.a.b.d).to eq "aaa"
     end
   end
 
-  it 'should be a method that calls SymbolMatrix.new with its arguments' do 
-    argument = stub 'argument'
-    SymbolMatrix.should_receive(:new).with argument
+  it 'is a method that calls SymbolMatrix.new with its arguments' do
+    argument = double 'argument'
+    expect(SymbolMatrix).to receive(:new).with argument
     SymbolMatrix argument
   end
 end
 
-describe SymbolMatrix::KeyNotDefinedException do 
-  it 'should be a subclass of NoMethodError' do 
-    SymbolMatrix::KeyNotDefinedException
-      .superclass.should == NoMethodError
+describe SymbolMatrix::KeyNotDefinedException do
+  it 'is a subclass of NoMethodError' do
+    expect(
+      SymbolMatrix::KeyNotDefinedException.superclass
+    ).to eq NoMethodError
   end
 end

--- a/spec/writer/symbolmatrix_spec.rb
+++ b/spec/writer/symbolmatrix_spec.rb
@@ -1,41 +1,41 @@
 require 'complete_features_helper'
 
-describe Writer::SymbolMatrix do 
-  describe '#initialize' do 
-    it 'should set the argument as the source' do 
-      source = stub 'source'
+describe Writer::SymbolMatrix do
+  describe '#initialize' do
+    it 'sets the argument as the source' do
+      source = double 'source'
       writer = Writer::SymbolMatrix.new source
-      writer.source.should == source
+      expect(writer.source).to eq source
     end
   end
 
-  describe '#hash' do 
-    it "should return an instance of Hash" do
+  describe '#hash' do
+    it "returns an instance of Hash" do
       m = SymbolMatrix[:b, 1]
       writer = Writer::SymbolMatrix.new m
-      writer.hash.should be_instance_of Hash
+      expect(writer.hash).to be_instance_of Hash
     end
-    
-    it "should have the same keys" do
+
+    it "has the same keys" do
       m = SymbolMatrix[:a, 1]
       writer = Writer::SymbolMatrix.new m
-      writer.hash[:a].should == 1
+      expect(writer.hash[:a]).to eq 1
     end
 
-    it "should have the same keys (more keys)" do
+    it "has the same keys (more keys)" do
       m = SymbolMatrix[:a, 2]
       writer = Writer::SymbolMatrix.new m
-      writer.hash[:a].should == 2
+      expect(writer.hash[:a]).to eq 2
     end
-    
+
     context "there is some SymbolMatrix within this SymbolMatrix" do
-      it "should recursively call #to.hash in it" do
-        in_writer = stub 'inside writer'
+      it "recursively calls #to.hash in it" do
+        in_writer = double 'inside writer'
 
         inside = SymbolMatrix.new
-        inside.should_receive(:to).and_return in_writer
-        in_writer.should_receive(:hash)
-        
+        expect(inside).to receive(:to).and_return in_writer
+        expect(in_writer).to receive(:hash)
+
         m = SymbolMatrix[:a, inside]
         writer = Writer::SymbolMatrix.new m
         writer.hash
@@ -43,86 +43,110 @@ describe Writer::SymbolMatrix do
     end
   end
 
-  shared_examples_for 'any writer serialization' do 
-    it 'should serialize "try: this" into "try:this"' do 
+  shared_examples_for 'any writer serialization' do
+    it 'serializes "try: this" into "try:this"' do
       s = SymbolMatrix try: "this"
       writer = Writer::SymbolMatrix.new s
-      writer.send(@method).should == "try:this"
+      expect(writer.send(@method)).to eq "try:this"
     end
 
-    it 'should serialize "try: that" into "try:that"' do 
+    it 'serializes "try: that" into "try:that"' do
       s = SymbolMatrix try: "that"
-      Writer::SymbolMatrix
-        .new(s).send(@method).should == "try:that"
+      expect(
+        Writer::SymbolMatrix
+          .new(s).send(@method)
+      ).to eq "try:that"
     end
 
-    it 'should serialize "attempt: this" into "attempt:this"' do
-      Writer::SymbolMatrix
-        .new(SymbolMatrix(attempt: "this"))
-        .send(@method).should == "attempt:this"
+    it 'serializes "attempt: this" into "attempt:this"' do
+      expect(
+        Writer::SymbolMatrix
+          .new(SymbolMatrix(attempt: "this"))
+          .send(@method)
+      ).to eq "attempt:this"
     end
 
-    it 'should serialize "attempt: that" into "attempt:that"' do
-      Writer::SymbolMatrix
-        .new(SymbolMatrix(attempt: "that"))
-        .send(@method).should == "attempt:that"
+    it 'serializes "attempt: that" into "attempt:that"' do
+      expect(
+        Writer::SymbolMatrix
+          .new(SymbolMatrix(attempt: "that"))
+          .send(@method)
+      ).to eq "attempt:that"
     end
 
-    it 'should serialize a more complex hash' do 
-      Writer::SymbolMatrix
-        .new(SymbolMatrix(a: "b", c: "d"))
-        .send(@method).should == "a:b c:d"
+    it 'serializes a more complex hash' do
+      expect(
+        Writer::SymbolMatrix
+          .new(SymbolMatrix(a: "b", c: "d"))
+          .send(@method)
+      ).to eq "a:b c:d"
     end
 
-    it 'should serialize a more complex hash with different values' do 
-      Writer::SymbolMatrix
-        .new(SymbolMatrix(g: "e", r: "t"))
-        .send(@method).should == "g:e r:t"
+    it 'serializes a more complex hash with different values' do
+      expect(
+        Writer::SymbolMatrix
+          .new(SymbolMatrix(g: "e", r: "t"))
+          .send(@method)
+      ).to eq "g:e r:t"
     end
 
-    it 'should serialize a multidimentional hash' do 
-      Writer::SymbolMatrix
-        .new(SymbolMatrix(g: {e: "s"}))
-        .send(@method).should == "g.e:s"
+    it 'serializes a multidimentional hash' do
+      expect(
+        Writer::SymbolMatrix
+          .new(SymbolMatrix(g: {e: "s"}))
+          .send(@method)
+      ).to eq "g.e:s"
     end
 
-    it 'should serialize a different multidimentional hash' do 
-      Writer::SymbolMatrix
-        .new(SymbolMatrix(r: {e: "s"}))
-        .send(@method).should == "r.e:s"
+    it 'serializes a different multidimentional hash' do
+      expect(
+        Writer::SymbolMatrix
+          .new(SymbolMatrix(r: {e: "s"}))
+          .send(@method)
+      ).to eq "r.e:s"
     end
 
-    it 'should serialize a yet different multidimentional hash' do 
-      Writer::SymbolMatrix
-        .new(SymbolMatrix(r: {a: "s"}))
-        .send(@method).should == "r.a:s"
+    it 'serializes a yet different multidimentional hash' do
+      expect(
+        Writer::SymbolMatrix
+          .new(SymbolMatrix(r: {a: "s"}))
+          .send(@method)
+      ).to eq "r.a:s"
     end
 
-    it 'should serialize a more complex multidimentional hash' do 
-      Writer::SymbolMatrix
-        .new(SymbolMatrix(r: {a: "s", f: "o"}))
-        .send(@method).should == "r.a:s r.f:o"
+    it 'serializes a more complex multidimentional hash' do
+      expect(
+        Writer::SymbolMatrix
+          .new(SymbolMatrix(r: {a: "s", f: "o"}))
+          .send(@method)
+      ).to eq "r.a:s r.f:o"
     end
 
-    it 'should serialize a different more complex multidimentional hash' do 
-      Writer::SymbolMatrix
-        .new(SymbolMatrix(r: {ar: "s", fe: "o"}))
-        .send(@method).should == "r.ar:s r.fe:o"
+    it 'serializes a different more complex multidimentional hash' do
+      expect(
+        Writer::SymbolMatrix
+          .new(SymbolMatrix(r: {ar: "s", fe: "o"}))
+          .send(@method)
+      ).to eq "r.ar:s r.fe:o"
     end
 
-    it 'should serialize a yet different more complex multidimentional hash' do 
-      Writer::SymbolMatrix
-        .new(SymbolMatrix(r: {ar: "s", fe: "o", wh: "at"}))
-        .send(@method).should == "r.ar:s r.fe:o r.wh:at"
+    it 'serializes a yet different more complex multidimentional hash' do
+      expect(
+        Writer::SymbolMatrix
+          .new(SymbolMatrix(r: {ar: "s", fe: "o", wh: "at"}))
+          .send(@method)
+      ).to eq "r.ar:s r.fe:o r.wh:at"
     end
 
-    it 'should serialize a more complex multidimentional hash' do 
-      Writer::SymbolMatrix
-        .new(SymbolMatrix(r: {a: { f: "o", s: "h", y: "u"}}))
-        .send(@method).should == "r.a.f:o r.a.s:h r.a.y:u"
+    it 'serializes a more complex multidimentional hash' do
+      expect(
+        Writer::SymbolMatrix
+          .new(SymbolMatrix(r: {a: { f: "o", s: "h", y: "u"}}))
+          .send(@method)
+      ).to eq "r.a.f:o r.a.s:h r.a.y:u"
     end
 
-    it 'should transform the multidimentional hash into a simple dot and colons serialization' do 
+    it 'transforms the multidimentional hash into a simple dot and colons serialization' do
       multidimentional = SymbolMatrix.new hola: {
           the: "start",
           asdfdf: 8989,
@@ -131,50 +155,50 @@ describe Writer::SymbolMatrix do
           }
         },
         stuff: "oops"
-      
+
       writer = Writer::SymbolMatrix.new multidimentional
-      writer.send(@method).should == "hola.the:start hola.asdfdf:8989 hola.of.some:multidimentional stuff:oops"
+      expect(writer.send(@method)).to eq "hola.the:start hola.asdfdf:8989 hola.of.some:multidimentional stuff:oops"
     end
   end
 
-  describe '#serialization' do 
+  describe '#serialization' do
     before { @method = :serialization }
     it_behaves_like 'any writer serialization'
   end
 
-  describe '#smas' do 
+  describe '#smas' do
     before { @method = :smas }
     it_behaves_like 'any writer serialization'
   end
 
   describe '#json' do
-    it 'should return a json serialization' do 
+    it 'returns a json serialization' do
       sm = SymbolMatrix alpha: { beta: "gamma" }
       writer = Writer::SymbolMatrix.new sm
-      writer.json.should == '{"alpha":{"beta":"gamma"}}'
+      expect(writer.json).to eq '{"alpha":{"beta":"gamma"}}'
     end
   end
 
-  describe '#yaml' do 
-    it 'should return a yaml serialization' do
+  describe '#yaml' do
+    it 'returns a yaml serialization' do
       sm = SymbolMatrix alpha: { beta: "gamma" }
       writer = Writer::SymbolMatrix.new sm
-      writer.yaml.should include "alpha:\n  beta: gamma"
+      expect(writer.yaml).to include "alpha:\n  beta: gamma"
     end
   end
 
-  describe '#string_key_hash' do 
-    it 'should convert a SymbolMatrix to a multidimentional hash with all string keys' do 
+  describe '#string_key_hash' do
+    it 'converts a SymbolMatrix to a multidimentional hash with all string keys' do
       sm = SymbolMatrix alpha: { beta: "gamma" }
       writer = Writer::SymbolMatrix.new sm
-      writer.string_key_hash
-        .should == { "alpha" => { "beta" => "gamma"} }
+      expect(writer.string_key_hash)
+        .to eq({ "alpha" => { "beta" => "gamma"} })
     end
   end
 end
 
 describe SymbolMatrix do
-  it 'should include the Discoverer for Writer' do 
-    SymbolMatrix.ancestors.should include Discoverer::Writer
+  it 'includes the Discoverer for Writer' do
+    expect(SymbolMatrix.ancestors).to include Discoverer::Writer
   end
 end


### PR DESCRIPTION
This is a need we've run into using this gem with time-dependent data, where we've wanted to include, for example, the current date in YAML files we're loading.

This change would allow ERB syntax in YAML, so we can load data like:

``` yaml
data:
  - id: 1
    created_at: <%= Time.now %>
```

In addition, I've updated tests to use rspec 3 syntax to remove deprecation warnings.
